### PR TITLE
moved dashboard nav items to be under reporting

### DIFF
--- a/src/Vicimus/ActionLog/ActionLogServiceProvider.php
+++ b/src/Vicimus/ActionLog/ActionLogServiceProvider.php
@@ -44,7 +44,7 @@ class ActionLogServiceProvider extends ServiceProvider {
 		});
 
 		//'View Log Report::'.\URL::to(ActionLog::$route) => 'made_up_thing',
-
+		/*
 		\Event::listen('ui.navigation.after', function() {
 			\Navigation::assemble(
 				array(
@@ -55,7 +55,7 @@ class ActionLogServiceProvider extends ServiceProvider {
 						),
 				)
 			);
-		}, 40);
+		}, 40);*/
 
 		if(class_exists('\DealerLive\Cms\Models\Page'))
 		{


### PR DESCRIPTION
Moved ActionLog dashboard items to appear under the Reporting heading, which means they now reside in the ReportingServiceProvider.
